### PR TITLE
Added License Headers and new PyPi Release

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,6 @@
+*Issue #, if available:*
+
+*Description of changes:*
+
+
+By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,12 @@
-build: egg-info
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+build:
 	python setup.py sdist
 
-egg-info: accustom.egg-info
-
-accustom.egg-info:
-	python setup.py egg_info
-
-clean: clean_build clean_egg
-
-clean_egg:
-	rm -fdr accustom.egg-info
+clean: clean_build
 
 clean_build:
 	rm -fdr dist
 
-.PHONY: build egg-info clean clean_egg clean_build
+.PHONY: build clean clean_build

--- a/THIRD-PARTY.txt
+++ b/THIRD-PARTY.txt
@@ -1,0 +1,213 @@
+** boto3; version 1.17.5 -- https://pypi.org/project/boto3/
+** botocore; version 1.20.5 -- https://github.com/boto/botocore
+** requests; version 2.25.1 -- https://github.com/psf/requests
+
+Apache License
+
+Version 2.0, January 2004
+
+http://www.apache.org/licenses/ TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND
+DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction, and
+      distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by the
+      copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all other
+      entities that control, are controlled by, or are under common control
+      with that entity. For the purposes of this definition, "control" means
+      (i) the power, direct or indirect, to cause the direction or management
+      of such entity, whether by contract or otherwise, or (ii) ownership of
+      fifty percent (50%) or more of the outstanding shares, or (iii)
+      beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity exercising
+      permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation source,
+      and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but not limited
+      to compiled object code, generated documentation, and conversions to
+      other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or Object
+      form, made available under the License, as indicated by a copyright
+      notice that is included in or attached to the work (an example is
+      provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object form,
+      that is based on (or derived from) the Work and for which the editorial
+      revisions, annotations, elaborations, or other modifications represent,
+      as a whole, an original work of authorship. For the purposes of this
+      License, Derivative Works shall not include works that remain separable
+      from, or merely link (or bind by name) to the interfaces of, the Work and
+      Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including the original
+      version of the Work and any modifications or additions to that Work or
+      Derivative Works thereof, that is intentionally submitted to Licensor for
+      inclusion in the Work by the copyright owner or by an individual or Legal
+      Entity authorized to submit on behalf of the copyright owner. For the
+      purposes of this definition, "submitted" means any form of electronic,
+      verbal, or written communication sent to the Licensor or its
+      representatives, including but not limited to communication on electronic
+      mailing lists, source code control systems, and issue tracking systems
+      that are managed by, or on behalf of, the Licensor for the purpose of
+      discussing and improving the Work, but excluding communication that is
+      conspicuously marked or otherwise designated in writing by the copyright
+      owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity on
+      behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of this
+   License, each Contributor hereby grants to You a perpetual, worldwide,
+   non-exclusive, no-charge, royalty-free, irrevocable copyright license to
+   reproduce, prepare Derivative Works of, publicly display, publicly perform,
+   sublicense, and distribute the Work and such Derivative Works in Source or
+   Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of this
+   License, each Contributor hereby grants to You a perpetual, worldwide,
+   non-exclusive, no-charge, royalty-free, irrevocable (except as stated in
+   this section) patent license to make, have made, use, offer to sell, sell,
+   import, and otherwise transfer the Work, where such license applies only to
+   those patent claims licensable by such Contributor that are necessarily
+   infringed by their Contribution(s) alone or by combination of their
+   Contribution(s) with the Work to which such Contribution(s) was submitted.
+   If You institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work or a
+   Contribution incorporated within the Work constitutes direct or contributory
+   patent infringement, then any patent licenses granted to You under this
+   License for that Work shall terminate as of the date such litigation is
+   filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the Work or
+   Derivative Works thereof in any medium, with or without modifications, and
+   in Source or Object form, provided that You meet the following conditions:
+
+      (a) You must give any other recipients of the Work or Derivative Works a
+      copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices stating
+      that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works that You
+      distribute, all copyright, patent, trademark, and attribution notices
+      from the Source form of the Work, excluding those notices that do not
+      pertain to any part of the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+      distribution, then any Derivative Works that You distribute must include
+      a readable copy of the attribution notices contained within such NOTICE
+      file, excluding those notices that do not pertain to any part of the
+      Derivative Works, in at least one of the following places: within a
+      NOTICE text file distributed as part of the Derivative Works; within the
+      Source form or documentation, if provided along with the Derivative
+      Works; or, within a display generated by the Derivative Works, if and
+      wherever such third-party notices normally appear. The contents of the
+      NOTICE file are for informational purposes only and do not modify the
+      License. You may add Your own attribution notices within Derivative Works
+      that You distribute, alongside or as an addendum to the NOTICE text from
+      the Work, provided that such additional attribution notices cannot be
+      construed as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and may
+      provide additional or different license terms and conditions for use,
+      reproduction, or distribution of Your modifications, or for any such
+      Derivative Works as a whole, provided Your use, reproduction, and
+      distribution of the Work otherwise complies with the conditions stated in
+      this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise, any
+   Contribution intentionally submitted for inclusion in the Work by You to the
+   Licensor shall be under the terms and conditions of this License, without
+   any additional terms or conditions. Notwithstanding the above, nothing
+   herein shall supersede or modify the terms of any separate license agreement
+   you may have executed with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor, except
+   as required for reasonable and customary use in describing the origin of the
+   Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or agreed to in
+   writing, Licensor provides the Work (and each Contributor provides its
+   Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   KIND, either express or implied, including, without limitation, any
+   warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or
+   FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining
+   the appropriateness of using or redistributing the Work and assume any risks
+   associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory, whether
+   in tort (including negligence), contract, or otherwise, unless required by
+   applicable law (such as deliberate and grossly negligent acts) or agreed to
+   in writing, shall any Contributor be liable to You for damages, including
+   any direct, indirect, special, incidental, or consequential damages of any
+   character arising as a result of this License or out of the use or inability
+   to use the Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all other
+   commercial damages or losses), even if such Contributor has been advised of
+   the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing the Work
+   or Derivative Works thereof, You may choose to offer, and charge a fee for,
+   acceptance of support, warranty, indemnity, or other liability obligations
+   and/or rights consistent with this License. However, in accepting such
+   obligations, You may act only on Your own behalf and on Your sole
+   responsibility, not on behalf of any other Contributor, and only if You
+   agree to indemnify, defend, and hold each Contributor harmless for any
+   liability incurred by, or claims asserted against, such Contributor by
+   reason of your accepting any such warranty or additional liability. END OF
+   TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following boilerplate
+notice, with the fields enclosed by brackets "[]" replaced with your own
+identifying information. (Don't include the brackets!) The text should be
+enclosed in the appropriate comment syntax for the file format. We also
+recommend that a file or class name and description of purpose be included on
+the same "printed page" as the copyright notice for easier identification
+within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+
+distributed under the License is distributed on an "AS IS" BASIS,
+
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+
+limitations under the License.
+
+* For boto3 see also this required NOTICE:
+    boto3
+    Copyright 2013-2017 Amazon.com, Inc. or its affiliates. All Rights
+    Reserved.
+* For botocore see also this required NOTICE:
+    Botocore
+    Copyright 2012-2017 Amazon.com, Inc. or its affiliates. All Rights
+    Reserved.
+* For requests see also this required NOTICE:
+    Requests
+    Copyright 2019 Kenneth Reitz

--- a/accustom/Exceptions/__init__.py
+++ b/accustom/Exceptions/__init__.py
@@ -1,3 +1,6 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 # Bring exceptions into the root of the submodule
 
 from .exceptions import CannotApplyRuleToStandaloneRedactionConfig

--- a/accustom/Exceptions/exceptions.py
+++ b/accustom/Exceptions/exceptions.py
@@ -1,3 +1,6 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """ Exceptions for the accustom library.
 
 These are the exceptions that can be returned by accustom

--- a/accustom/Testing/test_constants.py
+++ b/accustom/Testing/test_constants.py
@@ -1,3 +1,6 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 from accustom import Status
 from accustom import RequestType
 from accustom import RedactMode

--- a/accustom/Testing/test_redaction.py
+++ b/accustom/Testing/test_redaction.py
@@ -1,3 +1,6 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 from accustom import RedactionRuleSet
 from accustom import RedactionConfig
 from accustom import StandaloneRedactionConfig

--- a/accustom/Testing/test_response.py
+++ b/accustom/Testing/test_response.py
@@ -1,3 +1,6 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 from accustom import is_valid_event
 from accustom import cfnresponse
 from accustom import ResponseObject

--- a/accustom/__init__.py
+++ b/accustom/__init__.py
@@ -1,3 +1,6 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 # Import classes, functions, and submodules to be accessible from library
 from .constants import Status
 from .constants import RequestType

--- a/accustom/constants.py
+++ b/accustom/constants.py
@@ -1,3 +1,6 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """ Constants for the accustom library.
 
 These are constants are the Custom Resource Request Type Constants

--- a/accustom/decorators.py
+++ b/accustom/decorators.py
@@ -1,3 +1,6 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """ Decorators for the accustom library.
 
 This includes two decorators, one for the handler function, and one to apply to any resource handling

--- a/accustom/redaction.py
+++ b/accustom/redaction.py
@@ -1,3 +1,6 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """ RedactionConfig and StandaloneRedactConfig for the accustom library
 
 This allows you to define a redaction policy for accustom

--- a/accustom/response.py
+++ b/accustom/response.py
@@ -1,3 +1,6 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """ ResponseObject and cfnresponse function for the accustom library
 
 This allows you to communicate with CloudFormation
@@ -147,7 +150,7 @@ def cfnresponse(event: dict, responseStatus: str, responseReason: str = None, re
     responseBody['StackId'] = event['StackId']
     responseBody['RequestId'] = event['RequestId']
     responseBody['LogicalResourceId'] = event['LogicalResourceId']
-    if responseData is not None: responseBody['Data'] = responseData 
+    if responseData is not None: responseBody['Data'] = responseData
     if squashPrintResponse: responseBody['NoEcho'] = 'true'
 
     json_responseBody = json.dumps(responseBody)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,7 @@
-botocore>=1.10
-boto3>=1.8
-requests>=2.0
-requests-mock>=1.5
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+botocore>=1.20
+boto3>=1.17
+requests>=2.20
+requests-mock>=1.8

--- a/setup.py
+++ b/setup.py
@@ -1,18 +1,28 @@
-from distutils.core import setup
-from setuptools import find_packages
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from setuptools import setup
+import os
+
+
+def read(fname):
+    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+
 
 setup(
-    name = 'accustom',
-    version = '1.1.0',
-    description = 'Custom resource library for AWS CloudFormation',
-    long_description = 'Accustom is a library for responding to Custom Resources in AWS CloudFormation using the decorator pattern.',
-    url = 'https://github.com/awslabs/accustom',
-    author = 'Taylor Bertie',
-    author_email = 'nightkhaos@gmail.com',
-    license = 'Apache-2.0',
-    download_url = 'https://github.com/awslabs/cloudformation-accustom/archive/1.1.0.tar.gz',
-    keywords = ['cloudformation','lambda','custom','resource','decorator'],
-    classifiers = [
+    name='accustom',
+    version='1.1.0',
+    description='Accustom is a library for responding to Custom Resources in AWS CloudFormation using the decorator '
+                'pattern.',
+    long_description=read('README.md'),
+    long_description_content_type='text/markdown',
+    url='https://github.com/awslabs/cloudformation-accustom',
+    author='Taylor Bertie',
+    author_email='bertiet@amazon.com',
+    license='Apache-2.0',
+    download_url='https://github.com/awslabs/cloudformation-accustom/archive/1.1.0.tar.gz',
+    keywords=['cloudformation', 'lambda', 'custom', 'resource', 'decorator'],
+    classifiers=[
         # How mature is this project? Common values are
         #   3 - Alpha
         #   4 - Beta
@@ -29,13 +39,13 @@ setup(
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
-    packages = ['accustom', 'accustom.Exceptions'],
+    packages=['accustom', 'accustom.Exceptions'],
     install_requires=[
         'botocore>=1.10',
         'boto3>=1.8',
         'requests>=2.0'
     ],
-    python_requires='>=3, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, <4',
-    )
+    python_requires='>=3, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, !=3.6.*, <4',
+)

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 setup(
     name='accustom',
-    version='1.1.0',
+    version='1.1.1',
     description='Accustom is a library for responding to Custom Resources in AWS CloudFormation using the decorator '
                 'pattern.',
     long_description=read('README.md'),
@@ -20,7 +20,7 @@ setup(
     author='Taylor Bertie',
     author_email='bertiet@amazon.com',
     license='Apache-2.0',
-    download_url='https://github.com/awslabs/cloudformation-accustom/archive/1.1.0.tar.gz',
+    download_url='https://github.com/awslabs/cloudformation-accustom/archive/1.1.1.tar.gz',
     keywords=['cloudformation', 'lambda', 'custom', 'resource', 'decorator'],
     classifiers=[
         # How mature is this project? Common values are
@@ -43,9 +43,9 @@ setup(
     ],
     packages=['accustom', 'accustom.Exceptions'],
     install_requires=[
-        'botocore>=1.10',
-        'boto3>=1.8',
-        'requests>=2.0'
+        'botocore>=1.20',
+        'boto3>=1.17',
+        'requests>=2.20'
     ],
     python_requires='>=3, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, !=3.6.*, <4',
 )

--- a/templates/redact_testing/Makefile
+++ b/templates/redact_testing/Makefile
@@ -1,3 +1,6 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 package: redact_testing.deploy.ready.yaml
 
 %.deploy.ready.yaml: %.deploy.yaml %.zip

--- a/templates/redact_testing/redact_testing.deploy.yaml
+++ b/templates/redact_testing/redact_testing.deploy.yaml
@@ -1,3 +1,6 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 AWSTemplateFormatVersion: 2010-09-09
 Description: >
   This template deploys accustom using a function that will timeout before it completes.

--- a/templates/redact_testing/redact_testing.execute.yaml
+++ b/templates/redact_testing/redact_testing.execute.yaml
@@ -1,3 +1,6 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 AWSTemplateFormatVersion: "2010-09-09"
 Description: >
   This template tests the deployed function and executes it. It should fail to complete in time and not timeout.

--- a/templates/redact_testing/redact_testing.py
+++ b/templates/redact_testing/redact_testing.py
@@ -1,3 +1,6 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import logging
 logging.getLogger().setLevel(logging.DEBUG)
 

--- a/templates/test_timeout/Makefile
+++ b/templates/test_timeout/Makefile
@@ -1,3 +1,6 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 package: test_timeout.deploy.ready.yaml
 
 %.deploy.ready.yaml: %.deploy.yaml %.zip

--- a/templates/test_timeout/test_timeout.deploy.yaml
+++ b/templates/test_timeout/test_timeout.deploy.yaml
@@ -1,3 +1,6 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 AWSTemplateFormatVersion: 2010-09-09
 Description: >
   This template deploys accustom using a function that will timeout before it completes.

--- a/templates/test_timeout/test_timeout.execute.yaml
+++ b/templates/test_timeout/test_timeout.execute.yaml
@@ -1,3 +1,6 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 AWSTemplateFormatVersion: "2010-09-09"
 Description: >
   This template tests the deployed function and executes it. It should fail to complete in time and not timeout.

--- a/templates/test_timeout/test_timeout.execute2.yaml
+++ b/templates/test_timeout/test_timeout.execute2.yaml
@@ -1,3 +1,6 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 AWSTemplateFormatVersion: "2010-09-09"
 Description: >
   This template tests the deployed function and executes it. It should fail to complete in time and not timeout.

--- a/templates/test_timeout/test_timeout.py
+++ b/templates/test_timeout/test_timeout.py
@@ -1,3 +1,6 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import logging
 logging.getLogger().setLevel(logging.DEBUG)
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Change from MIT license to Apache 2.0 license and add appropriate code headers. PyPi required a new version despite there being no code changes, other than comments, between 1.1.0 and 1.1.1.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
