### PR TITLE
Cherrypick Release: Language changes to move away from Blacklist/Whitelist to Allowlist/Blocklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # CloudFormation Accustom
 Accustom is a library for responding to Custom Resources in AWS CloudFormation using the decorator pattern.
 
-This library was written based upon the same decorator methods used by the [cfnlambda](https://github.com/gene1wood/cfnlambda) library written by Gene Wood. As that library is no longer maintained I wrote a new version.
+This library was written based upon the same decorator methods used by the [cfnlambda](https://github.com/gene1wood/cfnlambda) library written by Gene Wood. Unfortunately the library is no longer maintained I wrote a new version.
 
 This library provides a cfnresponse method, some helper static classes, and some decorator methods to help with the function.
 
@@ -32,9 +32,9 @@ The quickest way to use this library is to use the standalone decorator `@accust
 import accustom
 @accustom.sdecorator(expectedProperties=['key1','key2'])
 def resource_handler(event, context):
-     sum = (float(event['ResourceProperties']['key1']) +
+     result = (float(event['ResourceProperties']['key1']) +
             float(event['ResourceProperties']['key2']))
-     return { 'sum' : sum }
+     return { 'sum' : result }
 ```
 
 In this configuration, the decorator will check to make sure the properties `key1` and `key2` have been passed by the user, and automatically send a response back to CloudFormation based upon the `event` object.
@@ -75,7 +75,7 @@ It takes the following option:
 The most useful of these options is `expectedProperties`. With it is possible to quickly define mandatory properties for your resource and fail if they are not included.
 
 ### `@accustom.sdecorator()`
-This decorator is just a combination of `@accustom.decorator()` and `@accustom.rdecorator()`. This allows you have a single, stand alone resource handler that has some defined properties and can automatically handle delete. The options available to it is the combination of both of the options available to the other two Decorators, with the exception of `redactProperties` which takes an accustom.StandaloneRedactionConfig object instead of a accustom.RedactionConfig object. For more information on `redactProperties` see "Redacting Confidential Information From Logs".
+This decorator is just a combination of `@accustom.decorator()` and `@accustom.rdecorator()`. This allows you to have a single, stand-alone resource handler that has some defined properties and can automatically handle delete. The options available to it is the combination of both of the options available to the other two Decorators, except for `redactProperties` which takes an accustom.StandaloneRedactionConfig object instead of an accustom.RedactionConfig object. For more information on `redactProperties` see "Redacting Confidential Information From Logs".
 
 The other important note about combining these two decorators is that `hideResourceDeleteFailure` becomes redundant if `decoratorHandleDelete` is set to `True`.
 
@@ -119,30 +119,30 @@ import accustom
 ```
 
 ## Redacting Confidential Information From `DEBUG` Logs
-If you often pass confidential information like passwords and secrets in properties to Custom Resources, you may want to prevent certain properties from being printed to debug logs. To help with this we provide a functionality to either blacklist or whitelist Resource Properties based upon provided regular expressions.
+If you often pass confidential information like passwords and secrets in properties to Custom Resources, you may want to prevent certain properties from being printed to debug logs. To help with this we provide a functionality to either blocklist or allowlist Resource Properties based upon provided regular expressions.
 
 To utilise this functionality you must initialise and include a `RedactionConfig`. A `RedactionConfig` consists of some flags to define the redaction mode and if the response URL should be redacted, as well as a series of `RedactionRuleSet` objects that define what to redact based upon regular expressions. There is a special case of `RedactionConfig` called a `StandaloneRedactionConfig` that has one, and only one, `RedactionRuleSet` that is provided at initialisation.
 
-Each `RedactionRuleSet` defines a single regex that defines which ResourceTypes this rule set should applied too. You can then apply any number of rules, based upon explicit an property name, or a regex. Please see the definitions and an example below.
+Each `RedactionRuleSet` defines a single regex that defines which ResourceTypes this rule set should be applied too. You can then apply any number of rules, based upon an explicit property name, or a regex. Please see the definitions, and an example below.
 
 ### `RedactionRuleSet`
-The `RedactionRuleSet` object allows you to define a series of properties or regexes which to whitelist or blacklist for a given resource type regex. It is initialised with the following:
+The `RedactionRuleSet` object allows you to define a series of properties or regexes which to allowlist or blocklist for a given resource type regex. It is initialised with the following:
 
 - `resourceRegex` (String) : The regex used to work out what resources to apply this too.
 
 #### `add_property_regex(propertiesRegex)`
 
-- `propertiesRegex` (String) : The regex used to work out what properties to whitelist/blacklist
+- `propertiesRegex` (String) : The regex used to work out what properties to allowlist/blocklist
 
 #### `add_property(propertyName)`
 
-- `propertyName` (String) : The name of the property to whitelist/blacklist
+- `propertyName` (String) : The name of the property to allowlist/blocklist
 
 
 ### `RedactionConfig`
-The `RedactionConfig` object allows you to create a collection of `RedactionRuleSet` objects as well as define what mode (whitelist/blacklist) to use, and if the presigned URL provided by CloudFormation should be redacted from the logs.
+The `RedactionConfig` object allows you to create a collection of `RedactionRuleSet` objects as well as define what mode (allowlist/blocklist) to use, and if the presigned URL provided by CloudFormation should be redacted from the logs.
 
-- `redactMode` (accustom.RedactMode) : What redaction mode should be used, if it should be a blacklist or whitelist
+- `redactMode` (accustom.RedactMode) : What redaction mode should be used, if it should be a blocklist or allowlist
 - `redactResponseURL` (Boolean) : If the response URL should be not be logged.
 
 #### `add_rule_set(ruleSet)`
@@ -150,9 +150,9 @@ The `RedactionConfig` object allows you to create a collection of `RedactionRule
 - `ruleSet` (accustom.RedactionRuleSet) : The rule set to be added to the RedactionConfig
 
 ### `StandaloneRedactionConfig`
-The `StandaloneRedactionConfig` object allows you to apply a single `RedactionRuleSet` object as well as define what mode (whitelist/blacklist) to use, and if the presigned URL provided by CloudFormation should be redacted from the logs.
+The `StandaloneRedactionConfig` object allows you to apply a single `RedactionRuleSet` object as well as define what mode (allowlist/blocklist) to use, and if the presigned URL provided by CloudFormation should be redacted from the logs.
 
-- `redactMode` (accustom.RedactMode) : What redaction mode should be used, if it should be a blacklist or whitelist
+- `redactMode` (accustom.RedactMode) : What redaction mode should be used, if it should be a blocklist or allowlist
 - `redactResponseURL` (Boolean) : If the response URL should be not be logged.
 - `ruleSet` (accustom.RedactionRuleSet) : The rule set to be added to the RedactionConfig
 
@@ -164,7 +164,7 @@ All resources will have properties called `Test` and `Example` redacted and repl
 
 Finally, as `redactResponseURL` is set to `True`, the response URL will not be printed in the debug logs.
    
-```python
+```python3
 from accustom import RedactionRuleSet, RedactionConfig, decorator
 
 ruleSetDefault = RedactionRuleSet()
@@ -181,9 +181,9 @@ rc.add_rule_set(ruleSetCustom)
     
 @decorator(redactConfig=rc)
 def resource_handler(event, context):
-    sum = (float(event['ResourceProperties']['Test']) +
+    result = (float(event['ResourceProperties']['Test']) +
            float(event['ResourceProperties']['Example']))
-    return { 'sum' : sum }
+    return { 'sum' : result }
 ```
 
 ## Note on Timeouts and Permissions
@@ -210,8 +210,8 @@ We provide three constants for ease of use:
 
 ### `RedactMode`
 
-- Blacklisting : `accustom.RedactMode.BLACKLIST`
-- Whitelisting : `accustom.RedactMode.WHITELIST`
+- Blocklisting : `accustom.RedactMode.BLOCKLIST`
+- Allowlisting : `accustom.RedactMode.ALLOWLIST`
 
 ## How to Contribute
 Feel free to open issues, fork, or submit a pull request:

--- a/accustom/Testing/test_constants.py
+++ b/accustom/Testing/test_constants.py
@@ -25,6 +25,12 @@ class RequestTypeTests(TestCase):
 
 
 class RedactModeTests(TestCase):
+    def test_blocklist(self):
+        self.assertEqual('block', RedactMode.BLOCKLIST)
+
+    def test_allowlist(self):
+        self.assertEqual('allow', RedactMode.ALLOWLIST)
+
     def test_blacklist(self):
         self.assertEqual('black', RedactMode.BLACKLIST)
 

--- a/accustom/Testing/test_redaction.py
+++ b/accustom/Testing/test_redaction.py
@@ -3,6 +3,7 @@ from accustom import RedactionConfig
 from accustom import StandaloneRedactionConfig
 from accustom import RedactMode
 from accustom.Exceptions import CannotApplyRuleToStandaloneRedactionConfig
+import logging
 
 from unittest import TestCase, main as umain
 
@@ -18,7 +19,7 @@ class RedactionRuleSetTests(TestCase):
     def test_init(self):
         # This test ignores the setUp resources
         rs = RedactionRuleSet('^Custom::Test$')
-        self.assertEqual(rs.resourceRegex, '^Custom::Test$')
+        self.assertEqual('^Custom::Test$', rs.resourceRegex)
 
     def test_invalid_init(self):
         # This test ignores the setUp Resources
@@ -26,7 +27,7 @@ class RedactionRuleSetTests(TestCase):
             RedactionRuleSet(0)
 
     def test_default_regex(self):
-        self.assertEqual(self.ruleSet.resourceRegex, '^.*$')
+        self.assertEqual('^.*$', self.ruleSet.resourceRegex)
 
     def test_adding_regex(self):
         self.ruleSet.add_property_regex('^Test$')
@@ -58,13 +59,29 @@ class RedactionConfigTests(TestCase):
 
     def test_defaults(self):
         rc = RedactionConfig()
-        self.assertEqual(rc.redactMode, RedactMode.BLACKLIST)
+        self.assertEqual(rc.redactMode, RedactMode.BLOCKLIST)
         self.assertFalse(rc.redactResponseURL)
 
     def test_input_values(self):
-        rc = RedactionConfig(redactMode=RedactMode.WHITELIST, redactResponseURL=True)
-        self.assertEqual(rc.redactMode, RedactMode.WHITELIST)
+        rc = RedactionConfig(redactMode=RedactMode.ALLOWLIST, redactResponseURL=True)
+        self.assertEqual(rc.redactMode, RedactMode.ALLOWLIST)
         self.assertTrue(rc.redactResponseURL)
+
+    def test_whitelist_deprecated(self):
+        with self.assertLogs(level=logging.WARNING) as captured:
+            rc = RedactionConfig(redactMode=RedactMode.WHITELIST)
+
+        self.assertEqual(1, len(captured.records))
+        self.assertEqual("The usage of RedactMode.WHITELIST is deprecated, please change to use RedactMode.ALLOWLIST",
+                         captured.records[0].getMessage())
+
+    def test_blacklist_deprecated(self):
+        with self.assertLogs(level=logging.WARNING) as captured:
+            rc = RedactionConfig(redactMode=RedactMode.BLACKLIST)
+
+        self.assertEqual(1, len(captured.records), 1)
+        self.assertEqual("The usage of RedactMode.BLACKLIST is deprecated, please change to use RedactMode.BLOCKLIST",
+                         captured.records[0].getMessage())
 
     def test_invalid_input_values(self):
         with self.assertRaises(TypeError):
@@ -88,9 +105,9 @@ class RedactionConfigTests(TestCase):
 
     def test_redactResponseURL(self):
         rc = RedactionConfig(redactResponseURL=True)
-        event = {'RequestType' : 'Create',
-                 'RequestId' : 'abcded',
-                 'ResponseURL' : 'https://localhost',
+        event = {'RequestType': 'Create',
+                 'RequestId': 'abcded',
+                 'ResponseURL': 'https://localhost',
                  'StackId': 'arn:...',
                  'LogicalResourceId': 'Test',
                  'ResourceType': 'Custom::Test'}
@@ -99,13 +116,13 @@ class RedactionConfigTests(TestCase):
         self.assertIn('ResponseURL', event)
         self.assertNotIn('ResponseURL', revent)
 
-    def test_blacklist1(self):
-        rc = RedactionConfig(redactMode=RedactMode.BLACKLIST)
+    def test_blocklist1(self):
+        rc = RedactionConfig(redactMode=RedactMode.BLOCKLIST)
         rc.add_rule_set(self.ruleSetDefault)
         rc.add_rule_set(self.ruleSetCustom)
-        event = {'RequestType' : 'Create',
-                 'RequestId' : 'abcded',
-                 'ResponseURL' : 'https://localhost',
+        event = {'RequestType': 'Create',
+                 'RequestId': 'abcded',
+                 'ResponseURL': 'https://localhost',
                  'StackId': 'arn:...',
                  'LogicalResourceId': 'Test',
                  'ResourceType': 'Custom::Test',
@@ -117,26 +134,26 @@ class RedactionConfigTests(TestCase):
                                         'DoNotDelete': NOT_REDACTED_STRING}}
         revent = rc._redact(event)
 
-        self.assertEqual(event['ResourceProperties']['Test'], NOT_REDACTED_STRING)
-        self.assertEqual(revent['ResourceProperties']['Test'], REDACTED_STRING)
-        self.assertEqual(event['ResourceProperties']['Example'], NOT_REDACTED_STRING)
-        self.assertEqual(revent['ResourceProperties']['Example'], REDACTED_STRING)
-        self.assertEqual(event['ResourceProperties']['Custom'], NOT_REDACTED_STRING)
-        self.assertEqual(revent['ResourceProperties']['Custom'], REDACTED_STRING)
-        self.assertEqual(event['ResourceProperties']['DeleteMe1'], NOT_REDACTED_STRING)
-        self.assertEqual(revent['ResourceProperties']['DeleteMe1'], REDACTED_STRING)
-        self.assertEqual(event['ResourceProperties']['DeleteMe2'], NOT_REDACTED_STRING)
-        self.assertEqual(revent['ResourceProperties']['DeleteMe2'], REDACTED_STRING)
-        self.assertEqual(event['ResourceProperties']['DoNotDelete'], NOT_REDACTED_STRING)
-        self.assertEqual(revent['ResourceProperties']['DoNotDelete'], NOT_REDACTED_STRING)
+        self.assertEqual(NOT_REDACTED_STRING, event['ResourceProperties']['Test'])
+        self.assertEqual(REDACTED_STRING, revent['ResourceProperties']['Test'])
+        self.assertEqual(NOT_REDACTED_STRING, event['ResourceProperties']['Example'])
+        self.assertEqual(REDACTED_STRING, revent['ResourceProperties']['Example'])
+        self.assertEqual(NOT_REDACTED_STRING, event['ResourceProperties']['Custom'])
+        self.assertEqual(REDACTED_STRING, revent['ResourceProperties']['Custom'])
+        self.assertEqual(NOT_REDACTED_STRING, event['ResourceProperties']['DeleteMe1'])
+        self.assertEqual(REDACTED_STRING, revent['ResourceProperties']['DeleteMe1'])
+        self.assertEqual(NOT_REDACTED_STRING, event['ResourceProperties']['DeleteMe2'])
+        self.assertEqual(REDACTED_STRING, revent['ResourceProperties']['DeleteMe2'])
+        self.assertEqual(NOT_REDACTED_STRING, event['ResourceProperties']['DoNotDelete'])
+        self.assertEqual(NOT_REDACTED_STRING, revent['ResourceProperties']['DoNotDelete'])
 
-    def test_blacklist2(self):
-        rc = RedactionConfig(redactMode=RedactMode.BLACKLIST)
+    def test_blocklist2(self):
+        rc = RedactionConfig(redactMode=RedactMode.BLOCKLIST)
         rc.add_rule_set(self.ruleSetDefault)
         rc.add_rule_set(self.ruleSetCustom)
-        event = {'RequestType' : 'Create',
-                 'RequestId' : 'abcded',
-                 'ResponseURL' : 'https://localhost',
+        event = {'RequestType': 'Create',
+                 'RequestId': 'abcded',
+                 'ResponseURL': 'https://localhost',
                  'StackId': 'arn:...',
                  'LogicalResourceId': 'Test',
                  'ResourceType': 'Custom::Hello',
@@ -148,26 +165,26 @@ class RedactionConfigTests(TestCase):
                                         'DoNotDelete': NOT_REDACTED_STRING}}
         revent = rc._redact(event)
 
-        self.assertEqual(event['ResourceProperties']['Test'], NOT_REDACTED_STRING)
-        self.assertEqual(revent['ResourceProperties']['Test'], REDACTED_STRING)
-        self.assertEqual(event['ResourceProperties']['Example'], NOT_REDACTED_STRING)
-        self.assertEqual(revent['ResourceProperties']['Example'], REDACTED_STRING)
-        self.assertEqual(event['ResourceProperties']['Custom'], NOT_REDACTED_STRING)
-        self.assertEqual(revent['ResourceProperties']['Custom'], NOT_REDACTED_STRING)
-        self.assertEqual(event['ResourceProperties']['DeleteMe1'], NOT_REDACTED_STRING)
-        self.assertEqual(revent['ResourceProperties']['DeleteMe1'], NOT_REDACTED_STRING)
-        self.assertEqual(event['ResourceProperties']['DeleteMe2'], NOT_REDACTED_STRING)
-        self.assertEqual(revent['ResourceProperties']['DeleteMe2'], NOT_REDACTED_STRING)
-        self.assertEqual(event['ResourceProperties']['DoNotDelete'], NOT_REDACTED_STRING)
-        self.assertEqual(revent['ResourceProperties']['DoNotDelete'], NOT_REDACTED_STRING)
+        self.assertEqual(NOT_REDACTED_STRING, event['ResourceProperties']['Test'])
+        self.assertEqual(REDACTED_STRING, revent['ResourceProperties']['Test'])
+        self.assertEqual(NOT_REDACTED_STRING, event['ResourceProperties']['Example'])
+        self.assertEqual(REDACTED_STRING, revent['ResourceProperties']['Example'])
+        self.assertEqual(NOT_REDACTED_STRING, event['ResourceProperties']['Custom'])
+        self.assertEqual(NOT_REDACTED_STRING, revent['ResourceProperties']['Custom'])
+        self.assertEqual(NOT_REDACTED_STRING, event['ResourceProperties']['DeleteMe1'])
+        self.assertEqual(NOT_REDACTED_STRING, revent['ResourceProperties']['DeleteMe1'])
+        self.assertEqual(NOT_REDACTED_STRING, event['ResourceProperties']['DeleteMe2'])
+        self.assertEqual(NOT_REDACTED_STRING, revent['ResourceProperties']['DeleteMe2'])
+        self.assertEqual(NOT_REDACTED_STRING, event['ResourceProperties']['DoNotDelete'])
+        self.assertEqual(NOT_REDACTED_STRING, revent['ResourceProperties']['DoNotDelete'])
 
-    def test_whitelist1(self):
-        rc = RedactionConfig(redactMode=RedactMode.WHITELIST)
+    def test_allowlist1(self):
+        rc = RedactionConfig(redactMode=RedactMode.ALLOWLIST)
         rc.add_rule_set(self.ruleSetDefault)
         rc.add_rule_set(self.ruleSetCustom)
-        event = {'RequestType' : 'Create',
-                 'RequestId' : 'abcded',
-                 'ResponseURL' : 'https://localhost',
+        event = {'RequestType': 'Create',
+                 'RequestId': 'abcded',
+                 'ResponseURL': 'https://localhost',
                  'StackId': 'arn:...',
                  'LogicalResourceId': 'Test',
                  'ResourceType': 'Custom::Test',
@@ -179,26 +196,26 @@ class RedactionConfigTests(TestCase):
                                         'DoNotDelete': NOT_REDACTED_STRING}}
         revent = rc._redact(event)
 
-        self.assertEqual(event['ResourceProperties']['Test'], NOT_REDACTED_STRING)
-        self.assertEqual(revent['ResourceProperties']['Test'], NOT_REDACTED_STRING)
-        self.assertEqual(event['ResourceProperties']['Example'], NOT_REDACTED_STRING)
-        self.assertEqual(revent['ResourceProperties']['Example'], NOT_REDACTED_STRING)
-        self.assertEqual(event['ResourceProperties']['Custom'], NOT_REDACTED_STRING)
-        self.assertEqual(revent['ResourceProperties']['Custom'], NOT_REDACTED_STRING)
-        self.assertEqual(event['ResourceProperties']['DeleteMe1'], NOT_REDACTED_STRING)
-        self.assertEqual(revent['ResourceProperties']['DeleteMe1'], NOT_REDACTED_STRING)
-        self.assertEqual(event['ResourceProperties']['DeleteMe2'], NOT_REDACTED_STRING)
-        self.assertEqual(revent['ResourceProperties']['DeleteMe2'], NOT_REDACTED_STRING)
-        self.assertEqual(event['ResourceProperties']['DoNotDelete'], NOT_REDACTED_STRING)
-        self.assertEqual(revent['ResourceProperties']['DoNotDelete'], REDACTED_STRING)
+        self.assertEqual(NOT_REDACTED_STRING, event['ResourceProperties']['Test'])
+        self.assertEqual(NOT_REDACTED_STRING, revent['ResourceProperties']['Test'])
+        self.assertEqual(NOT_REDACTED_STRING, event['ResourceProperties']['Example'])
+        self.assertEqual(NOT_REDACTED_STRING, revent['ResourceProperties']['Example'])
+        self.assertEqual(NOT_REDACTED_STRING, event['ResourceProperties']['Custom'])
+        self.assertEqual(NOT_REDACTED_STRING, revent['ResourceProperties']['Custom'])
+        self.assertEqual(NOT_REDACTED_STRING, event['ResourceProperties']['DeleteMe1'])
+        self.assertEqual(NOT_REDACTED_STRING, revent['ResourceProperties']['DeleteMe1'])
+        self.assertEqual(NOT_REDACTED_STRING, event['ResourceProperties']['DeleteMe2'])
+        self.assertEqual(NOT_REDACTED_STRING, revent['ResourceProperties']['DeleteMe2'])
+        self.assertEqual(NOT_REDACTED_STRING, event['ResourceProperties']['DoNotDelete'])
+        self.assertEqual(REDACTED_STRING, revent['ResourceProperties']['DoNotDelete'])
 
-    def test_whitelist2(self):
-        rc = RedactionConfig(redactMode=RedactMode.WHITELIST)
+    def test_allowlist2(self):
+        rc = RedactionConfig(redactMode=RedactMode.ALLOWLIST)
         rc.add_rule_set(self.ruleSetDefault)
         rc.add_rule_set(self.ruleSetCustom)
-        event = {'RequestType' : 'Create',
-                 'RequestId' : 'abcded',
-                 'ResponseURL' : 'https://localhost',
+        event = {'RequestType': 'Create',
+                 'RequestId': 'abcded',
+                 'ResponseURL': 'https://localhost',
                  'StackId': 'arn:...',
                  'LogicalResourceId': 'Test',
                  'ResourceType': 'Custom::Hello',
@@ -210,26 +227,26 @@ class RedactionConfigTests(TestCase):
                                         'DoNotDelete': NOT_REDACTED_STRING}}
         revent = rc._redact(event)
 
-        self.assertEqual(event['ResourceProperties']['Test'], NOT_REDACTED_STRING)
-        self.assertEqual(revent['ResourceProperties']['Test'], NOT_REDACTED_STRING)
-        self.assertEqual(event['ResourceProperties']['Example'], NOT_REDACTED_STRING)
-        self.assertEqual(revent['ResourceProperties']['Example'], NOT_REDACTED_STRING)
-        self.assertEqual(event['ResourceProperties']['Custom'], NOT_REDACTED_STRING)
-        self.assertEqual(revent['ResourceProperties']['Custom'], REDACTED_STRING)
-        self.assertEqual(event['ResourceProperties']['DeleteMe1'], NOT_REDACTED_STRING)
-        self.assertEqual(revent['ResourceProperties']['DeleteMe1'], REDACTED_STRING)
-        self.assertEqual(event['ResourceProperties']['DeleteMe2'], NOT_REDACTED_STRING)
-        self.assertEqual(revent['ResourceProperties']['DeleteMe2'], REDACTED_STRING)
-        self.assertEqual(event['ResourceProperties']['DoNotDelete'], NOT_REDACTED_STRING)
-        self.assertEqual(revent['ResourceProperties']['DoNotDelete'], REDACTED_STRING)
+        self.assertEqual(NOT_REDACTED_STRING, event['ResourceProperties']['Test'])
+        self.assertEqual(NOT_REDACTED_STRING, revent['ResourceProperties']['Test'])
+        self.assertEqual(NOT_REDACTED_STRING, event['ResourceProperties']['Example'])
+        self.assertEqual(NOT_REDACTED_STRING, revent['ResourceProperties']['Example'])
+        self.assertEqual(NOT_REDACTED_STRING, event['ResourceProperties']['Custom'])
+        self.assertEqual(REDACTED_STRING, revent['ResourceProperties']['Custom'])
+        self.assertEqual(NOT_REDACTED_STRING, event['ResourceProperties']['DeleteMe1'])
+        self.assertEqual(REDACTED_STRING, revent['ResourceProperties']['DeleteMe1'])
+        self.assertEqual(NOT_REDACTED_STRING, event['ResourceProperties']['DeleteMe2'])
+        self.assertEqual(REDACTED_STRING, revent['ResourceProperties']['DeleteMe2'])
+        self.assertEqual(NOT_REDACTED_STRING, event['ResourceProperties']['DoNotDelete'])
+        self.assertEqual(REDACTED_STRING, revent['ResourceProperties']['DoNotDelete'])
 
     def test_oldproperties1(self):
-        rc = RedactionConfig(redactMode=RedactMode.BLACKLIST)
+        rc = RedactionConfig(redactMode=RedactMode.BLOCKLIST)
         rc.add_rule_set(self.ruleSetDefault)
         rc.add_rule_set(self.ruleSetCustom)
-        event = {'RequestType' : 'Update',
-                 'RequestId' : 'abcded',
-                 'ResponseURL' : 'https://localhost',
+        event = {'RequestType': 'Update',
+                 'RequestId': 'abcded',
+                 'ResponseURL': 'https://localhost',
                  'StackId': 'arn:...',
                  'LogicalResourceId': 'Test',
                  'PhysicalResourceId': 'Test',
@@ -248,39 +265,39 @@ class RedactionConfigTests(TestCase):
                                            'DoNotDelete': NOT_REDACTED_STRING}}
         revent = rc._redact(event)
 
-        self.assertEqual(event['ResourceProperties']['Test'], NOT_REDACTED_STRING)
-        self.assertEqual(revent['ResourceProperties']['Test'], REDACTED_STRING)
-        self.assertEqual(event['ResourceProperties']['Example'], NOT_REDACTED_STRING)
-        self.assertEqual(revent['ResourceProperties']['Example'], REDACTED_STRING)
-        self.assertEqual(event['ResourceProperties']['Custom'], NOT_REDACTED_STRING)
-        self.assertEqual(revent['ResourceProperties']['Custom'], NOT_REDACTED_STRING)
-        self.assertEqual(event['ResourceProperties']['DeleteMe1'], NOT_REDACTED_STRING)
-        self.assertEqual(revent['ResourceProperties']['DeleteMe1'], NOT_REDACTED_STRING)
-        self.assertEqual(event['ResourceProperties']['DeleteMe2'], NOT_REDACTED_STRING)
-        self.assertEqual(revent['ResourceProperties']['DeleteMe2'], NOT_REDACTED_STRING)
-        self.assertEqual(event['ResourceProperties']['DoNotDelete'], NOT_REDACTED_STRING)
-        self.assertEqual(revent['ResourceProperties']['DoNotDelete'], NOT_REDACTED_STRING)
+        self.assertEqual(NOT_REDACTED_STRING, event['ResourceProperties']['Test'])
+        self.assertEqual(REDACTED_STRING, revent['ResourceProperties']['Test'])
+        self.assertEqual(NOT_REDACTED_STRING, event['ResourceProperties']['Example'])
+        self.assertEqual(REDACTED_STRING, revent['ResourceProperties']['Example'])
+        self.assertEqual(NOT_REDACTED_STRING, event['ResourceProperties']['Custom'])
+        self.assertEqual(NOT_REDACTED_STRING, revent['ResourceProperties']['Custom'])
+        self.assertEqual(NOT_REDACTED_STRING, event['ResourceProperties']['DeleteMe1'])
+        self.assertEqual(NOT_REDACTED_STRING, revent['ResourceProperties']['DeleteMe1'])
+        self.assertEqual(NOT_REDACTED_STRING, event['ResourceProperties']['DeleteMe2'])
+        self.assertEqual(NOT_REDACTED_STRING, revent['ResourceProperties']['DeleteMe2'])
+        self.assertEqual(NOT_REDACTED_STRING, event['ResourceProperties']['DoNotDelete'])
+        self.assertEqual(NOT_REDACTED_STRING, revent['ResourceProperties']['DoNotDelete'])
 
-        self.assertEqual(event['OldResourceProperties']['Test'], NOT_REDACTED_STRING)
-        self.assertEqual(revent['OldResourceProperties']['Test'], REDACTED_STRING)
-        self.assertEqual(event['OldResourceProperties']['Example'], NOT_REDACTED_STRING)
-        self.assertEqual(revent['OldResourceProperties']['Example'], REDACTED_STRING)
-        self.assertEqual(event['OldResourceProperties']['Custom'], NOT_REDACTED_STRING)
-        self.assertEqual(revent['OldResourceProperties']['Custom'], NOT_REDACTED_STRING)
-        self.assertEqual(event['OldResourceProperties']['DeleteMe1'], NOT_REDACTED_STRING)
-        self.assertEqual(revent['OldResourceProperties']['DeleteMe1'], NOT_REDACTED_STRING)
-        self.assertEqual(event['OldResourceProperties']['DeleteMe2'], NOT_REDACTED_STRING)
-        self.assertEqual(revent['OldResourceProperties']['DeleteMe2'], NOT_REDACTED_STRING)
-        self.assertEqual(event['OldResourceProperties']['DoNotDelete'], NOT_REDACTED_STRING)
-        self.assertEqual(revent['OldResourceProperties']['DoNotDelete'], NOT_REDACTED_STRING)
+        self.assertEqual(NOT_REDACTED_STRING, event['OldResourceProperties']['Test'])
+        self.assertEqual(REDACTED_STRING, revent['OldResourceProperties']['Test'])
+        self.assertEqual(NOT_REDACTED_STRING, event['OldResourceProperties']['Example'])
+        self.assertEqual(REDACTED_STRING, revent['OldResourceProperties']['Example'])
+        self.assertEqual(NOT_REDACTED_STRING, event['OldResourceProperties']['Custom'])
+        self.assertEqual(NOT_REDACTED_STRING, revent['OldResourceProperties']['Custom'])
+        self.assertEqual(NOT_REDACTED_STRING, event['OldResourceProperties']['DeleteMe1'])
+        self.assertEqual(NOT_REDACTED_STRING, revent['OldResourceProperties']['DeleteMe1'])
+        self.assertEqual(NOT_REDACTED_STRING, event['OldResourceProperties']['DeleteMe2'])
+        self.assertEqual(NOT_REDACTED_STRING, revent['OldResourceProperties']['DeleteMe2'])
+        self.assertEqual(NOT_REDACTED_STRING, event['OldResourceProperties']['DoNotDelete'])
+        self.assertEqual(NOT_REDACTED_STRING, revent['OldResourceProperties']['DoNotDelete'])
 
     def test_oldproperties2(self):
-        rc = RedactionConfig(redactMode=RedactMode.WHITELIST)
+        rc = RedactionConfig(redactMode=RedactMode.ALLOWLIST)
         rc.add_rule_set(self.ruleSetDefault)
         rc.add_rule_set(self.ruleSetCustom)
-        event = {'RequestType' : 'Update',
-                 'RequestId' : 'abcded',
-                 'ResponseURL' : 'https://localhost',
+        event = {'RequestType': 'Update',
+                 'RequestId': 'abcded',
+                 'ResponseURL': 'https://localhost',
                  'StackId': 'arn:...',
                  'LogicalResourceId': 'Test',
                  'PhysicalResourceId': 'Test',
@@ -299,31 +316,31 @@ class RedactionConfigTests(TestCase):
                                            'DoNotDelete': NOT_REDACTED_STRING}}
         revent = rc._redact(event)
 
-        self.assertEqual(event['ResourceProperties']['Test'], NOT_REDACTED_STRING)
-        self.assertEqual(revent['ResourceProperties']['Test'], NOT_REDACTED_STRING)
-        self.assertEqual(event['ResourceProperties']['Example'], NOT_REDACTED_STRING)
-        self.assertEqual(revent['ResourceProperties']['Example'], NOT_REDACTED_STRING)
-        self.assertEqual(event['ResourceProperties']['Custom'], NOT_REDACTED_STRING)
-        self.assertEqual(revent['ResourceProperties']['Custom'], REDACTED_STRING)
-        self.assertEqual(event['ResourceProperties']['DeleteMe1'], NOT_REDACTED_STRING)
-        self.assertEqual(revent['ResourceProperties']['DeleteMe1'], REDACTED_STRING)
-        self.assertEqual(event['ResourceProperties']['DeleteMe2'], NOT_REDACTED_STRING)
-        self.assertEqual(revent['ResourceProperties']['DeleteMe2'], REDACTED_STRING)
-        self.assertEqual(event['ResourceProperties']['DoNotDelete'], NOT_REDACTED_STRING)
-        self.assertEqual(revent['ResourceProperties']['DoNotDelete'], REDACTED_STRING)
+        self.assertEqual(NOT_REDACTED_STRING, event['ResourceProperties']['Test'])
+        self.assertEqual(NOT_REDACTED_STRING, revent['ResourceProperties']['Test'])
+        self.assertEqual(NOT_REDACTED_STRING, event['ResourceProperties']['Example'])
+        self.assertEqual(NOT_REDACTED_STRING, revent['ResourceProperties']['Example'])
+        self.assertEqual(NOT_REDACTED_STRING, event['ResourceProperties']['Custom'])
+        self.assertEqual(REDACTED_STRING, revent['ResourceProperties']['Custom'])
+        self.assertEqual(NOT_REDACTED_STRING, event['ResourceProperties']['DeleteMe1'])
+        self.assertEqual(REDACTED_STRING, revent['ResourceProperties']['DeleteMe1'])
+        self.assertEqual(NOT_REDACTED_STRING, event['ResourceProperties']['DeleteMe2'])
+        self.assertEqual(REDACTED_STRING, revent['ResourceProperties']['DeleteMe2'])
+        self.assertEqual(NOT_REDACTED_STRING, event['ResourceProperties']['DoNotDelete'])
+        self.assertEqual(REDACTED_STRING, revent['ResourceProperties']['DoNotDelete'])
 
-        self.assertEqual(event['OldResourceProperties']['Test'], NOT_REDACTED_STRING)
-        self.assertEqual(revent['OldResourceProperties']['Test'], NOT_REDACTED_STRING)
-        self.assertEqual(event['OldResourceProperties']['Example'], NOT_REDACTED_STRING)
-        self.assertEqual(revent['OldResourceProperties']['Example'], NOT_REDACTED_STRING)
-        self.assertEqual(event['OldResourceProperties']['Custom'], NOT_REDACTED_STRING)
-        self.assertEqual(revent['OldResourceProperties']['Custom'], REDACTED_STRING)
-        self.assertEqual(event['OldResourceProperties']['DeleteMe1'], NOT_REDACTED_STRING)
-        self.assertEqual(revent['OldResourceProperties']['DeleteMe1'], REDACTED_STRING)
-        self.assertEqual(event['OldResourceProperties']['DeleteMe2'], NOT_REDACTED_STRING)
-        self.assertEqual(revent['OldResourceProperties']['DeleteMe2'], REDACTED_STRING)
-        self.assertEqual(event['OldResourceProperties']['DoNotDelete'], NOT_REDACTED_STRING)
-        self.assertEqual(revent['OldResourceProperties']['DoNotDelete'], REDACTED_STRING)
+        self.assertEqual(NOT_REDACTED_STRING, event['OldResourceProperties']['Test'])
+        self.assertEqual(NOT_REDACTED_STRING, revent['OldResourceProperties']['Test'])
+        self.assertEqual(NOT_REDACTED_STRING, event['OldResourceProperties']['Example'])
+        self.assertEqual(NOT_REDACTED_STRING, revent['OldResourceProperties']['Example'])
+        self.assertEqual(NOT_REDACTED_STRING, event['OldResourceProperties']['Custom'])
+        self.assertEqual(REDACTED_STRING, revent['OldResourceProperties']['Custom'])
+        self.assertEqual(NOT_REDACTED_STRING, event['OldResourceProperties']['DeleteMe1'])
+        self.assertEqual(REDACTED_STRING, revent['OldResourceProperties']['DeleteMe1'])
+        self.assertEqual(NOT_REDACTED_STRING, event['OldResourceProperties']['DeleteMe2'])
+        self.assertEqual(REDACTED_STRING, revent['OldResourceProperties']['DeleteMe2'])
+        self.assertEqual(NOT_REDACTED_STRING, event['OldResourceProperties']['DoNotDelete'])
+        self.assertEqual(REDACTED_STRING, revent['OldResourceProperties']['DoNotDelete'])
 
 
 class StandaloneRedactionConfigTests(TestCase):
@@ -339,13 +356,29 @@ class StandaloneRedactionConfigTests(TestCase):
 
     def test_defaults(self):
         rc = StandaloneRedactionConfig(self.ruleSetDefault)
-        self.assertEqual(rc.redactMode, RedactMode.BLACKLIST)
+        self.assertEqual(RedactMode.BLOCKLIST, rc.redactMode)
         self.assertFalse(rc.redactResponseURL)
 
     def test_input_values(self):
-        rc = StandaloneRedactionConfig(self.ruleSetDefault, redactMode=RedactMode.WHITELIST, redactResponseURL=True)
-        self.assertEqual(rc.redactMode, RedactMode.WHITELIST)
+        rc = StandaloneRedactionConfig(self.ruleSetDefault, redactMode=RedactMode.ALLOWLIST, redactResponseURL=True)
+        self.assertEqual(RedactMode.ALLOWLIST, rc.redactMode)
         self.assertTrue(rc.redactResponseURL)
+
+    def test_whitelist_deprecated(self):
+        with self.assertLogs(level=logging.WARNING) as captured:
+            rc = StandaloneRedactionConfig(self.ruleSetDefault, redactMode=RedactMode.WHITELIST)
+
+        self.assertEqual(1, len(captured.records))
+        self.assertEqual("The usage of RedactMode.WHITELIST is deprecated, please change to use RedactMode.ALLOWLIST",
+                         captured.records[0].getMessage())
+
+    def test_blacklist_deprecated(self):
+        with self.assertLogs(level=logging.WARNING) as captured:
+            rc = StandaloneRedactionConfig(self.ruleSetDefault, redactMode=RedactMode.BLACKLIST)
+
+        self.assertEqual(1, len(captured.records), 1)
+        self.assertEqual("The usage of RedactMode.BLACKLIST is deprecated, please change to use RedactMode.BLOCKLIST",
+                         captured.records[0].getMessage())
 
     def test_invalid_input_values(self):
         with self.assertRaises(TypeError):
@@ -367,9 +400,9 @@ class StandaloneRedactionConfigTests(TestCase):
 
     def test_redactResponseURL(self):
         rc = StandaloneRedactionConfig(self.ruleSetDefault, redactResponseURL=True)
-        event = {'RequestType' : 'Create',
-                 'RequestId' : 'abcded',
-                 'ResponseURL' : 'https://localhost',
+        event = {'RequestType': 'Create',
+                 'RequestId': 'abcded',
+                 'ResponseURL': 'https://localhost',
                  'StackId': 'arn:...',
                  'LogicalResourceId': 'Test',
                  'ResourceType': 'Custom::Test'}
@@ -378,11 +411,11 @@ class StandaloneRedactionConfigTests(TestCase):
         self.assertIn('ResponseURL', event)
         self.assertNotIn('ResponseURL', revent)
 
-    def test_blacklist(self):
-        rc = StandaloneRedactionConfig(self.ruleSetDefault, redactMode=RedactMode.BLACKLIST)
-        event = {'RequestType' : 'Create',
-                 'RequestId' : 'abcded',
-                 'ResponseURL' : 'https://localhost',
+    def test_blocklist(self):
+        rc = StandaloneRedactionConfig(self.ruleSetDefault, redactMode=RedactMode.BLOCKLIST)
+        event = {'RequestType': 'Create',
+                 'RequestId': 'abcded',
+                 'ResponseURL': 'https://localhost',
                  'StackId': 'arn:...',
                  'LogicalResourceId': 'Test',
                  'ResourceType': 'Custom::Test',
@@ -394,24 +427,24 @@ class StandaloneRedactionConfigTests(TestCase):
                                         'DoNotDelete': NOT_REDACTED_STRING}}
         revent = rc._redact(event)
 
-        self.assertEqual(event['ResourceProperties']['Test'], NOT_REDACTED_STRING)
-        self.assertEqual(revent['ResourceProperties']['Test'], REDACTED_STRING)
-        self.assertEqual(event['ResourceProperties']['Example'], NOT_REDACTED_STRING)
-        self.assertEqual(revent['ResourceProperties']['Example'], REDACTED_STRING)
-        self.assertEqual(event['ResourceProperties']['Custom'], NOT_REDACTED_STRING)
-        self.assertEqual(revent['ResourceProperties']['Custom'], NOT_REDACTED_STRING)
-        self.assertEqual(event['ResourceProperties']['DeleteMe1'], NOT_REDACTED_STRING)
-        self.assertEqual(revent['ResourceProperties']['DeleteMe1'], NOT_REDACTED_STRING)
-        self.assertEqual(event['ResourceProperties']['DeleteMe2'], NOT_REDACTED_STRING)
-        self.assertEqual(revent['ResourceProperties']['DeleteMe2'], NOT_REDACTED_STRING)
-        self.assertEqual(event['ResourceProperties']['DoNotDelete'], NOT_REDACTED_STRING)
-        self.assertEqual(revent['ResourceProperties']['DoNotDelete'], NOT_REDACTED_STRING)
+        self.assertEqual(NOT_REDACTED_STRING, event['ResourceProperties']['Test'])
+        self.assertEqual(REDACTED_STRING, revent['ResourceProperties']['Test'])
+        self.assertEqual(NOT_REDACTED_STRING, event['ResourceProperties']['Example'])
+        self.assertEqual(REDACTED_STRING, revent['ResourceProperties']['Example'])
+        self.assertEqual(NOT_REDACTED_STRING, event['ResourceProperties']['Custom'])
+        self.assertEqual(NOT_REDACTED_STRING, revent['ResourceProperties']['Custom'])
+        self.assertEqual(NOT_REDACTED_STRING, event['ResourceProperties']['DeleteMe1'])
+        self.assertEqual(NOT_REDACTED_STRING, revent['ResourceProperties']['DeleteMe1'])
+        self.assertEqual(NOT_REDACTED_STRING, event['ResourceProperties']['DeleteMe2'])
+        self.assertEqual(NOT_REDACTED_STRING, revent['ResourceProperties']['DeleteMe2'])
+        self.assertEqual(NOT_REDACTED_STRING, event['ResourceProperties']['DoNotDelete'])
+        self.assertEqual(NOT_REDACTED_STRING, revent['ResourceProperties']['DoNotDelete'])
 
-    def test_whitelist(self):
-        rc = StandaloneRedactionConfig(self.ruleSetDefault, redactMode=RedactMode.WHITELIST)
-        event = {'RequestType' : 'Create',
-                 'RequestId' : 'abcded',
-                 'ResponseURL' : 'https://localhost',
+    def test_allowlist(self):
+        rc = StandaloneRedactionConfig(self.ruleSetDefault, redactMode=RedactMode.ALLOWLIST)
+        event = {'RequestType': 'Create',
+                 'RequestId': 'abcded',
+                 'ResponseURL': 'https://localhost',
                  'StackId': 'arn:...',
                  'LogicalResourceId': 'Test',
                  'ResourceType': 'Custom::Hello',
@@ -423,27 +456,27 @@ class StandaloneRedactionConfigTests(TestCase):
                                         'DoNotDelete': NOT_REDACTED_STRING}}
         revent = rc._redact(event)
 
-        self.assertEqual(event['ResourceProperties']['Test'], NOT_REDACTED_STRING)
-        self.assertEqual(revent['ResourceProperties']['Test'], NOT_REDACTED_STRING)
-        self.assertEqual(event['ResourceProperties']['Example'], NOT_REDACTED_STRING)
-        self.assertEqual(revent['ResourceProperties']['Example'], NOT_REDACTED_STRING)
-        self.assertEqual(event['ResourceProperties']['Custom'], NOT_REDACTED_STRING)
-        self.assertEqual(revent['ResourceProperties']['Custom'], REDACTED_STRING)
-        self.assertEqual(event['ResourceProperties']['DeleteMe1'], NOT_REDACTED_STRING)
-        self.assertEqual(revent['ResourceProperties']['DeleteMe1'], REDACTED_STRING)
-        self.assertEqual(event['ResourceProperties']['DeleteMe2'], NOT_REDACTED_STRING)
-        self.assertEqual(revent['ResourceProperties']['DeleteMe2'], REDACTED_STRING)
-        self.assertEqual(event['ResourceProperties']['DoNotDelete'], NOT_REDACTED_STRING)
-        self.assertEqual(revent['ResourceProperties']['DoNotDelete'], REDACTED_STRING)
+        self.assertEqual(NOT_REDACTED_STRING, event['ResourceProperties']['Test'])
+        self.assertEqual(NOT_REDACTED_STRING, revent['ResourceProperties']['Test'])
+        self.assertEqual(NOT_REDACTED_STRING, event['ResourceProperties']['Example'])
+        self.assertEqual(NOT_REDACTED_STRING, revent['ResourceProperties']['Example'])
+        self.assertEqual(NOT_REDACTED_STRING, event['ResourceProperties']['Custom'])
+        self.assertEqual(REDACTED_STRING, revent['ResourceProperties']['Custom'])
+        self.assertEqual(NOT_REDACTED_STRING, event['ResourceProperties']['DeleteMe1'])
+        self.assertEqual(REDACTED_STRING, revent['ResourceProperties']['DeleteMe1'])
+        self.assertEqual(NOT_REDACTED_STRING, event['ResourceProperties']['DeleteMe2'])
+        self.assertEqual(REDACTED_STRING, revent['ResourceProperties']['DeleteMe2'])
+        self.assertEqual(NOT_REDACTED_STRING, event['ResourceProperties']['DoNotDelete'])
+        self.assertEqual(REDACTED_STRING, revent['ResourceProperties']['DoNotDelete'])
 
     def test_oldproperties(self):
-        rc = StandaloneRedactionConfig(self.ruleSetDefault, redactMode=RedactMode.WHITELIST)
-        event = {'RequestType' : 'Update',
-                 'RequestId' : 'abcded',
-                 'ResponseURL' : 'https://localhost',
+        rc = StandaloneRedactionConfig(self.ruleSetDefault, redactMode=RedactMode.ALLOWLIST)
+        event = {'RequestType': 'Update',
+                 'RequestId': 'abcded',
+                 'ResponseURL': 'https://localhost',
                  'StackId': 'arn:...',
                  'LogicalResourceId': 'Test',
-                 'PhysicalResourceId' : 'Test',
+                 'PhysicalResourceId': 'Test',
                  'ResourceType': 'Custom::Hello',
                  'ResourceProperties': {'Test': NOT_REDACTED_STRING,
                                         'Example': NOT_REDACTED_STRING,
@@ -459,31 +492,31 @@ class StandaloneRedactionConfigTests(TestCase):
                                            'DoNotDelete': NOT_REDACTED_STRING}}
         revent = rc._redact(event)
 
-        self.assertEqual(event['ResourceProperties']['Test'], NOT_REDACTED_STRING)
-        self.assertEqual(revent['ResourceProperties']['Test'], NOT_REDACTED_STRING)
-        self.assertEqual(event['ResourceProperties']['Example'], NOT_REDACTED_STRING)
-        self.assertEqual(revent['ResourceProperties']['Example'], NOT_REDACTED_STRING)
-        self.assertEqual(event['ResourceProperties']['Custom'], NOT_REDACTED_STRING)
-        self.assertEqual(revent['ResourceProperties']['Custom'], REDACTED_STRING)
-        self.assertEqual(event['ResourceProperties']['DeleteMe1'], NOT_REDACTED_STRING)
-        self.assertEqual(revent['ResourceProperties']['DeleteMe1'], REDACTED_STRING)
-        self.assertEqual(event['ResourceProperties']['DeleteMe2'], NOT_REDACTED_STRING)
-        self.assertEqual(revent['ResourceProperties']['DeleteMe2'], REDACTED_STRING)
-        self.assertEqual(event['ResourceProperties']['DoNotDelete'], NOT_REDACTED_STRING)
-        self.assertEqual(revent['ResourceProperties']['DoNotDelete'], REDACTED_STRING)
+        self.assertEqual(NOT_REDACTED_STRING, event['ResourceProperties']['Test'])
+        self.assertEqual(NOT_REDACTED_STRING, revent['ResourceProperties']['Test'])
+        self.assertEqual(NOT_REDACTED_STRING, event['ResourceProperties']['Example'])
+        self.assertEqual(NOT_REDACTED_STRING, revent['ResourceProperties']['Example'])
+        self.assertEqual(NOT_REDACTED_STRING, event['ResourceProperties']['Custom'])
+        self.assertEqual(REDACTED_STRING, revent['ResourceProperties']['Custom'])
+        self.assertEqual(NOT_REDACTED_STRING, event['ResourceProperties']['DeleteMe1'])
+        self.assertEqual(REDACTED_STRING, revent['ResourceProperties']['DeleteMe1'])
+        self.assertEqual(NOT_REDACTED_STRING, event['ResourceProperties']['DeleteMe2'])
+        self.assertEqual(REDACTED_STRING, revent['ResourceProperties']['DeleteMe2'])
+        self.assertEqual(NOT_REDACTED_STRING, event['ResourceProperties']['DoNotDelete'])
+        self.assertEqual(REDACTED_STRING, revent['ResourceProperties']['DoNotDelete'])
 
-        self.assertEqual(event['OldResourceProperties']['Test'], NOT_REDACTED_STRING)
-        self.assertEqual(revent['OldResourceProperties']['Test'], NOT_REDACTED_STRING)
-        self.assertEqual(event['OldResourceProperties']['Example'], NOT_REDACTED_STRING)
-        self.assertEqual(revent['OldResourceProperties']['Example'], NOT_REDACTED_STRING)
-        self.assertEqual(event['OldResourceProperties']['Custom'], NOT_REDACTED_STRING)
-        self.assertEqual(revent['OldResourceProperties']['Custom'], REDACTED_STRING)
-        self.assertEqual(event['OldResourceProperties']['DeleteMe1'], NOT_REDACTED_STRING)
-        self.assertEqual(revent['OldResourceProperties']['DeleteMe1'], REDACTED_STRING)
-        self.assertEqual(event['OldResourceProperties']['DeleteMe2'], NOT_REDACTED_STRING)
-        self.assertEqual(revent['OldResourceProperties']['DeleteMe2'], REDACTED_STRING)
-        self.assertEqual(event['OldResourceProperties']['DoNotDelete'], NOT_REDACTED_STRING)
-        self.assertEqual(revent['OldResourceProperties']['DoNotDelete'], REDACTED_STRING)
+        self.assertEqual(NOT_REDACTED_STRING, event['OldResourceProperties']['Test'])
+        self.assertEqual(NOT_REDACTED_STRING, revent['OldResourceProperties']['Test'])
+        self.assertEqual(NOT_REDACTED_STRING, event['OldResourceProperties']['Example'])
+        self.assertEqual(NOT_REDACTED_STRING, revent['OldResourceProperties']['Example'])
+        self.assertEqual(NOT_REDACTED_STRING, event['OldResourceProperties']['Custom'])
+        self.assertEqual(REDACTED_STRING, revent['OldResourceProperties']['Custom'])
+        self.assertEqual(NOT_REDACTED_STRING, event['OldResourceProperties']['DeleteMe1'])
+        self.assertEqual(REDACTED_STRING, revent['OldResourceProperties']['DeleteMe1'])
+        self.assertEqual(NOT_REDACTED_STRING, event['OldResourceProperties']['DeleteMe2'])
+        self.assertEqual(REDACTED_STRING, revent['OldResourceProperties']['DeleteMe2'])
+        self.assertEqual(NOT_REDACTED_STRING, event['OldResourceProperties']['DoNotDelete'])
+        self.assertEqual(REDACTED_STRING, revent['OldResourceProperties']['DoNotDelete'])
 
 
 if __name__ == '__main__':

--- a/accustom/Testing/test_response.py
+++ b/accustom/Testing/test_response.py
@@ -11,69 +11,73 @@ from accustom.Exceptions import FailedToSendResponseException
 import requests_mock
 from unittest import TestCase, main as umain
 
-class valid_event_tests(TestCase):
+
+class ValidEventTests(TestCase):
     def test_missing_field(self):
         event = {
-            "RequestType" : RequestType.CREATE,
-            "ResponseURL" : "https://test.url",
-            "StackId" : None,
-            "RequestId" : None,
-            "ResourceType" : None,
+            "RequestType": RequestType.CREATE,
+            "ResponseURL": "https://test.url",
+            "StackId": None,
+            "RequestId": None,
+            "ResourceType": None,
         }
         self.assertFalse(is_valid_event(event))
 
     def test_no_valid_request_type(self):
         event = {
-            "RequestType" : "DESTROY",
-            "ResponseURL" : "https://test.url",
-            "StackId" : None,
-            "RequestId" : None,
-            "ResourceType" : None,
-            "LogicalResourceId" : None
+            "RequestType": "DESTROY",
+            "ResponseURL": "https://test.url",
+            "StackId": None,
+            "RequestId": None,
+            "ResourceType": None,
+            "LogicalResourceId": None
         }
         self.assertFalse(is_valid_event(event))
 
     def test_invalid_url(self):
         event = {
-            "RequestType" : RequestType.CREATE,
-            "ResponseURL" : "ftp://test.url",
-            "StackId" : None,
-            "RequestId" : None,
-            "ResourceType" : None,
-            "LogicalResourceId" : None
+            "RequestType": RequestType.CREATE,
+            "ResponseURL": "ftp://test.url",
+            "StackId": None,
+            "RequestId": None,
+            "ResourceType": None,
+            "LogicalResourceId": None
         }
         self.assertFalse(is_valid_event(event))
 
     def test_missing_physical(self):
         event = {
-            "RequestType" : RequestType.UPDATE,
-            "ResponseURL" : "https://test.url",
-            "StackId" : None,
-            "RequestId" : None,
-            "ResourceType" : None,
-            "LogicalResourceId" : None
+            "RequestType": RequestType.UPDATE,
+            "ResponseURL": "https://test.url",
+            "StackId": None,
+            "RequestId": None,
+            "ResourceType": None,
+            "LogicalResourceId": None
         }
         self.assertFalse(is_valid_event(event))
 
     def test_included_physical(self):
         event = {
-            "RequestType" : RequestType.DELETE,
-            "ResponseURL" : "https://test.url",
-            "StackId" : None,
-            "RequestId" : None,
-            "ResourceType" : None,
-            "LogicalResourceId" : None,
-            "PhysicalResourceId" : None
+            "RequestType": RequestType.DELETE,
+            "ResponseURL": "https://test.url",
+            "StackId": None,
+            "RequestId": None,
+            "ResourceType": None,
+            "LogicalResourceId": None,
+            "PhysicalResourceId": None
         }
         self.assertTrue(is_valid_event(event))
 
-class cfnresponseTests(TestCase):
+
+class ResponseTests(TestCase):
     pass
+
 
 class ResponseObjectTests(TestCase):
     pass
 
     # TODO: Implement response tests
+
 
 if __name__ == '__main__':
     umain()

--- a/accustom/constants.py
+++ b/accustom/constants.py
@@ -25,6 +25,9 @@ class RequestType:
 
 class RedactMode:
     """RedactMode Options"""
+    ALLOWLIST = 'allow'
+    BLOCKLIST = 'block'
 
+    # DEPRECATED NAMES
     BLACKLIST = 'black'
     WHITELIST = 'white'

--- a/accustom/decorators.py
+++ b/accustom/decorators.py
@@ -40,7 +40,6 @@ try:
 except ImportError:
     from botocore.vendored import requests
     logger.warning("botocore.vendored version of requests is deprecated. Please include requests in your code bundle.")
-import urllib3.exceptions
 
 
 # Time in milliseconds to set the alarm for (in milliseconds)
@@ -153,7 +152,7 @@ def decorator(enforceUseOfClass: bool = False, hideResourceDeleteFailure: bool =
                                  'Lambda API from within the function. As we may not have time to execute the ' +
                                  'function, returning failure.')
                     return ResponseObject(reason='Unable to call Lambda to do chained invoke, returning failure.',
-                                          responseStatus=Status.FAILED).send(event,context)
+                                          responseStatus=Status.FAILED).send(event, context)
                 except bexceptions.ReadTimeoutError:
                     # This should be a critical failure
                     logger.error('Waited the read timeout and function did not return, returning an error')

--- a/accustom/response.py
+++ b/accustom/response.py
@@ -29,7 +29,9 @@ try:
     import requests
 except ImportError:
     from botocore.vendored import requests
+
     logger.warning("botocore.vendored version of requests is deprecated. Please include requests in your code bundle.")
+
 
 def is_valid_event(event: dict) -> bool:
     """This function takes in a CloudFormation Request Object and checks for the required fields as per:
@@ -43,12 +45,12 @@ def is_valid_event(event: dict) -> bool:
 
     """
     if not (all(v in event for v in (
-        'RequestType',
-        'ResponseURL',
-        'StackId',
-        'RequestId',
-        'ResourceType',
-        'LogicalResourceId'
+            'RequestType',
+            'ResponseURL',
+            'StackId',
+            'RequestId',
+            'ResourceType',
+            'LogicalResourceId'
     ))):
         # Check we have all the required fields
         return False
@@ -135,7 +137,7 @@ def cfnresponse(event: dict, responseStatus: str, responseReason: str = None, re
                                                                                      context.log_stream_name)
 
     elif context is not None and responseReason is None:
-            responseReason = "See the details in CloudWatch Log Stream: %s" % context.log_stream_name
+        responseReason = "See the details in CloudWatch Log Stream: %s" % context.log_stream_name
 
     responseUrl = event['ResponseURL']
 
@@ -147,7 +149,7 @@ def cfnresponse(event: dict, responseStatus: str, responseReason: str = None, re
     responseBody['StackId'] = event['StackId']
     responseBody['RequestId'] = event['RequestId']
     responseBody['LogicalResourceId'] = event['LogicalResourceId']
-    if responseData is not None: responseBody['Data'] = responseData 
+    if responseData is not None: responseBody['Data'] = responseData
     if squashPrintResponse: responseBody['NoEcho'] = 'true'
 
     json_responseBody = json.dumps(responseBody)
@@ -193,6 +195,7 @@ def cfnresponse(event: dict, responseStatus: str, responseReason: str = None, re
 
 class ResponseObject(object):
     """Class that allows you to init a ResponseObject for easy function writing"""
+
     def __init__(self, data: dict = None, physicalResourceId: str = None, reason: str = None,
                  responseStatus: str = Status.SUCCESS, squashPrintResponse: bool = False):
         """Init function for the class

--- a/templates/redact_testing/redact_testing.py
+++ b/templates/redact_testing/redact_testing.py
@@ -1,7 +1,7 @@
 import logging
-logging.getLogger().setLevel(logging.DEBUG)
-
 from accustom import RedactionRuleSet, RedactionConfig, decorator
+
+logging.getLogger().setLevel(logging.DEBUG)
 
 ruleSetDefault = RedactionRuleSet()
 ruleSetDefault.add_property_regex('^Test$')
@@ -17,9 +17,10 @@ rc.add_rule_set(ruleSetCustom)
 
 logger = logging.getLogger(__name__)
 
+
 @decorator(hideResourceDeleteFailure=True,
            timeoutFunction=False,
            redactConfig=rc)
-def handler(event,context):
+def handler(event, context):
     # No action actually required since we'll be looking at CW Logs.
     pass


### PR DESCRIPTION
*Issue #, if available:* #18

*Description of changes:* This merges in the changes of issue #18 in as "Blacklist" and "Whitelist" have negative connotations, so needed to change them to something more acceptable. "Blacklist" and "Whitelist" will still work to preserve backwards compatibility with previous deployments written for versions 1.1.1 and earlier.

If "Blacklist" and "Whitelist" are used there will also be an error written to the logs at a WARNING level to inform users they need to move towards using "Allowlist" and "Blocklist"

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
